### PR TITLE
Add multi-schema support

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,8 @@
+line-length = 120
+indent-width = 2
+target-version = "py311"
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "cr-lf"

--- a/src/helper/date.py
+++ b/src/helper/date.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta
+
+
+# Obtains date based on context
+SUPPORTED_DATE_TOKENS: list[str] = ["today", "tomorrow", "yesterday"]
+
+
+def _generate_date_from_token(token: str) -> datetime:
+  token = token.lower().strip()
+  if token == "today":
+    return datetime.now()
+  elif token == "yesterday":
+    return datetime.now() - timedelta(days=1)
+  elif token == "tomorrow":
+    return datetime.now() + timedelta(days=1)
+  else:
+    print(f"helper > date.py > [WARNING] Only {SUPPORTED_DATE_TOKENS} tokens are accepted")
+    print("helper > date.py > [WARNING] Defaulting to 'today'")
+    return datetime.now()
+
+
+def _humanize_date(date: datetime) -> str:
+  return date.strftime("%B %d, %Y")
+
+
+def parse_date_from_token(token: str) -> str:
+  date: datetime = _generate_date_from_token(token)
+  return _humanize_date(date)

--- a/src/schema/sample_schema_01.py
+++ b/src/schema/sample_schema_01.py
@@ -1,0 +1,22 @@
+import json
+
+import spacy
+from spacy.tokens.doc import Doc
+
+
+def create_schema(text: str, nlp: spacy.language.Language) -> str:
+  doc: Doc = nlp(text)
+  data: dict = {"Person": {}, "Location": {}, "Event": {}}
+
+  # Extract entities and fill the schema
+  for ent in doc.ents:
+    if ent.label_ == "PERSON":
+      data["Person"]["Name"] = ent.text
+    elif ent.label_ == "GPE":
+      data["Location"]["City"] = ent.text
+    elif ent.label_ == "DATE":
+      data["Event"]["Date"] = ent.text
+    elif ent.label_ == "ORG":
+      data["Person"]["Occupation"] = ent.text
+
+  return json.dumps(data, indent=4)

--- a/src/schema/sample_schema_01.py
+++ b/src/schema/sample_schema_01.py
@@ -1,12 +1,16 @@
 import json
 
 import spacy
+from spacy import displacy
 from spacy.tokens.doc import Doc
 
 
-def create_schema(text: str, nlp: spacy.language.Language) -> str:
+def create_schema(text: str, nlp: spacy.language.Language, debug: bool = False) -> str:
   doc: Doc = nlp(text)
   data: dict = {"Person": {}, "Location": {}, "Event": {}}
+
+  if debug:
+    displacy.serve(doc, style="ent", host="localhost")
 
   # Extract entities and fill the schema
   for ent in doc.ents:

--- a/src/schema/task_schema_01.py
+++ b/src/schema/task_schema_01.py
@@ -1,0 +1,52 @@
+import json
+
+import spacy
+from spacy import displacy
+from spacy.matcher import Matcher
+from spacy.tokens.doc import Doc
+
+from src.helper.date import SUPPORTED_DATE_TOKENS, parse_date_from_token
+
+
+def create_schema(text: str, nlp: spacy.language.Language, debug: bool = False) -> str:
+  doc: Doc = nlp(text)
+  data: dict = {"Person": {}, "Task": {}}
+
+  if debug:
+    displacy.serve(doc, style="ent", host="localhost")
+
+  # Matcher to extract task performed
+  matcher = Matcher(nlp.vocab)
+  pattern: list[dict[str, str]] = [
+    {"POS": "VERB"},  # Action (Verb)
+    {"POS": "NOUN", "OP": "+"},  # Object of the action (Nouns)
+    {"LOWER": "on", "OP": "?"},  # Preposition (e.g., "on the car")
+    {"POS": "NOUN", "OP": "?"},  # Prepositional object (e.g., "car")
+  ]
+
+  matcher.add("TASK_PATTERN", [pattern])
+  matches: list[tuple] = matcher(doc)
+
+  longest_matched_task: str = ""
+  for match_id, start, end in matches:
+    matched_span = doc[start:end]
+    if len(matched_span.text) > len(longest_matched_task):
+      longest_matched_task = matched_span.text
+
+  # Extract entities and fill the schema
+  data["Task"]["Description"] = longest_matched_task
+  for ent in doc.ents:
+    if ent.label_ == "PERSON":
+      data["Person"]["Name"] = ent.text
+    if ent.label_ == "TIME":
+      data["Task"]["Duration"] = ent.text
+    elif ent.label_ == "ORG":
+      data["Task"]["Client"] = ent.text
+    elif ent.label_ == "DATE":
+      if ent.text.lower() in SUPPORTED_DATE_TOKENS:
+        parsed_date: str = parse_date_from_token(ent.text)
+        data["Task"]["Date"] = parsed_date
+      else:
+        data["Task"]["Date"] = ent.text
+
+  return json.dumps(data, indent=4)

--- a/transctiption2JSON.py
+++ b/transctiption2JSON.py
@@ -7,7 +7,7 @@ import src.schema.task_schema_01 as task_schema_01
 
 
 # Function to check and download the SpaCy model
-def load_spacy_model(model_name="en_core_web_sm") -> spacy.language.Language:
+def load_spacy_model(model_name="en_core_web_md") -> spacy.language.Language:
   try:
     # Try to load the model
     nlp = spacy.load(model_name)

--- a/transctiption2JSON.py
+++ b/transctiption2JSON.py
@@ -1,8 +1,8 @@
-import json
 import subprocess
 
 import spacy
-from spacy.tokens.doc import Doc
+
+import src.schema.sample_schema_01 as sample_schema_01
 
 
 # Function to check and download the SpaCy model
@@ -19,39 +19,17 @@ def load_spacy_model(model_name="en_core_web_sm"):
 
 
 # Load the SpaCy model
-nlp = load_spacy_model()
-
-
-# Define schema
-def create_schema(text) -> str:
-  doc: Doc = nlp(text)
-  data: dict = {"Person": {}, "Location": {}, "Event": {}}
-
-  # Extract entities and fill the schema
-  for ent in doc.ents:
-    if ent.label_ == "PERSON":
-      data["Person"]["Name"] = ent.text
-    elif ent.label_ == "GPE":
-      data["Location"]["City"] = ent.text
-    elif ent.label_ == "DATE":
-      data["Event"]["Date"] = ent.text
-    elif ent.label_ == "ORG":
-      data["Person"]["Occupation"] = ent.text
-
-  return json.dumps(data, indent=4)
-
+nlp: spacy.language.Language = load_spacy_model()
 
 # Sample text
 text = "John Doe, a software developer from San Francisco, attended a conference on October 5, 2024."
 
 # Convert text to JSON using the schema
-json_data: str = create_schema(text)
+json_data: str = sample_schema_01.create_schema(text, nlp)
+print(json_data)
 
 
-def transcription2JSONmain(text) -> str:
-  json_data: str = create_schema(text)
+def transcription2JSONmain(text: str) -> str:
+  json_data: str = sample_schema_01.create_schema(text, nlp)
   print("JSON Conversion", json_data)
   return json_data
-
-
-print(json_data)

--- a/transctiption2JSON.py
+++ b/transctiption2JSON.py
@@ -1,91 +1,57 @@
-# import openai
-# import json
-
-# # Set your OpenAI API key
-# openai.api_key = 'your_openai_api_key_here'
-
-# def convert_text_to_json(text):
-#     # Define the prompt for the model
-#     prompt = f"Convert the following text into a JSON object:\n{text}\nReturn only the JSON object."
-    
-#     response = openai.ChatCompletion.create(
-#         model="gpt-3.5-turbo",  # or another model of your choice
-#         messages=[{"role": "user", "content": prompt}],
-#         temperature=0,
-#         max_tokens=1500
-#     )
-    
-#     # Extract the content from the response
-#     json_text = response['choices'][0]['message']['content']
-    
-#     # Attempt to parse the response as JSON
-#     try:
-#         json_result = json.loads(json_text)
-#         return json_result
-#     except json.JSONDecodeError as e:
-#         print("Error decoding JSON:", e)
-#         return None
-
-# # Example usage
-# text_input = "Your input text goes here."
-# json_output = convert_text_to_json(text_input)
-# print(json_output)
-
-
-## Run this python -m spacy download en_core_web_sm
+import json
+import subprocess
 
 import spacy
-import subprocess
-import os
-import json  # Add this import
+from spacy.tokens.doc import Doc
+
 
 # Function to check and download the SpaCy model
 def load_spacy_model(model_name="en_core_web_sm"):
-    try:
-        # Try to load the model
-        nlp = spacy.load(model_name)
-    except OSError:
-        # Model not found, download it
-        print(f"Model {model_name} not found. Downloading now...")
-        subprocess.run(["python", "-m", "spacy", "download", model_name])
-        nlp = spacy.load(model_name)
-    return nlp
+  try:
+    # Try to load the model
+    nlp = spacy.load(model_name)
+  except OSError:
+    # Model not found, download it
+    print(f"Model {model_name} not found. Downloading now...")
+    subprocess.run(["python", "-m", "spacy", "download", model_name])
+    nlp = spacy.load(model_name)
+  return nlp
+
 
 # Load the SpaCy model
 nlp = load_spacy_model()
 
-# Define schema
-def create_schema(text):
-    doc = nlp(text)
-    data = {
-        "Person": {},
-        "Location": {},
-        "Event": {}
-    }
 
-    # Extract entities and fill the schema
-    for ent in doc.ents:
-        if ent.label_ == "PERSON":
-            data["Person"]["Name"] = ent.text
-        elif ent.label_ == "GPE":
-            data["Location"]["City"] = ent.text
-        elif ent.label_ == "DATE":
-            data["Event"]["Date"] = ent.text
-        elif ent.label_ == "ORG":
-            data["Person"]["Occupation"] = ent.text
-    
-    return json.dumps(data, indent=4)
+# Define schema
+def create_schema(text) -> str:
+  doc: Doc = nlp(text)
+  data: dict = {"Person": {}, "Location": {}, "Event": {}}
+
+  # Extract entities and fill the schema
+  for ent in doc.ents:
+    if ent.label_ == "PERSON":
+      data["Person"]["Name"] = ent.text
+    elif ent.label_ == "GPE":
+      data["Location"]["City"] = ent.text
+    elif ent.label_ == "DATE":
+      data["Event"]["Date"] = ent.text
+    elif ent.label_ == "ORG":
+      data["Person"]["Occupation"] = ent.text
+
+  return json.dumps(data, indent=4)
+
 
 # Sample text
 text = "John Doe, a software developer from San Francisco, attended a conference on October 5, 2024."
 
 # Convert text to JSON using the schema
-json_data = create_schema(text)
+json_data: str = create_schema(text)
 
-def transcription2JSONmain(text):
-    json_data = create_schema(text)
-    print("JSON Conversion", json_data) 
-    return json_data
+
+def transcription2JSONmain(text) -> str:
+  json_data: str = create_schema(text)
+  print("JSON Conversion", json_data)
+  return json_data
+
+
 print(json_data)
-
-

--- a/transctiption2JSON.py
+++ b/transctiption2JSON.py
@@ -6,7 +6,7 @@ import src.schema.sample_schema_01 as sample_schema_01
 
 
 # Function to check and download the SpaCy model
-def load_spacy_model(model_name="en_core_web_sm"):
+def load_spacy_model(model_name="en_core_web_sm") -> spacy.language.Language:
   try:
     # Try to load the model
     nlp = spacy.load(model_name)
@@ -14,7 +14,7 @@ def load_spacy_model(model_name="en_core_web_sm"):
     # Model not found, download it
     print(f"Model {model_name} not found. Downloading now...")
     subprocess.run(["python", "-m", "spacy", "download", model_name])
-    nlp = spacy.load(model_name)
+    nlp: spacy.language.Language = spacy.load(model_name)
   return nlp
 
 

--- a/transctiption2JSON.py
+++ b/transctiption2JSON.py
@@ -3,6 +3,7 @@ import subprocess
 import spacy
 
 import src.schema.sample_schema_01 as sample_schema_01
+import src.schema.task_schema_01 as task_schema_01
 
 
 # Function to check and download the SpaCy model
@@ -23,10 +24,14 @@ nlp: spacy.language.Language = load_spacy_model()
 
 # Sample text
 text = "John Doe, a software developer from San Francisco, attended a conference on October 5, 2024."
+task_text = "I'm John Doe, today I installed glass panels on the car for 5 hours for Acme Industries."
 
 # Convert text to JSON using the schema
 json_data: str = sample_schema_01.create_schema(text, nlp)
 print(json_data)
+
+task_json: str = task_schema_01.create_schema(task_text, nlp)
+print(task_json)
 
 
 def transcription2JSONmain(text: str) -> str:


### PR DESCRIPTION
- Add `ruff` formatter and config
  - To format code automatically, install `ruff` extension for VS Code and enable "Format on Save" option
- Add type hints
- Refactor schema definition
  - New schemas can be defined in `src/schema/`
- Switch to medium size variant of `spacy`
- Add `debug` parameter to `create_schema()` function
  - Use `create_schema(..., debug=True)` to use
  - This will open a `localhost` website to view the entities which matched with the input text
- Add `task_schema_01` as an alternative schema which includes person, task hours, task client, task date, and task description